### PR TITLE
Bump jQuery from 2.1.3 to 3.5.0 in /samples/aspnet/WebApi/Todo/Todo.Web

### DIFF
--- a/samples/aspnet/WebApi/Todo/Todo.Web/packages.config
+++ b/samples/aspnet/WebApi/Todo/Todo.Web/packages.config
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net45" />
   <package id="bootstrap" version="3.3.1" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.2" targetFramework="net45" />
-  <package id="jQuery" version="2.1.3" targetFramework="net45" />
+  <package id="jQuery" version="3.5.0" targetFramework="net45" />
   <package id="Knockout.Validation" version="2.0.2" targetFramework="net45" />
   <package id="knockoutjs" version="3.2.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.1.0" targetFramework="net45" />


### PR DESCRIPTION
Bumps jQuery from 2.1.3 to 3.5.0.

---
updated-dependencies:
- dependency-name: jQuery dependency-type: direct:production ...